### PR TITLE
Fix typos

### DIFF
--- a/basis/commitments.ipynb
+++ b/basis/commitments.ipynb
@@ -103,7 +103,7 @@
    "source": [
     "# Pedersen commitment (hiding)\n",
     "\n",
-    "There is a problem: Commiting to the same value yields the same commitment. This reveals something about the contained value!\n",
+    "There is a problem: Committing to the same value yields the same commitment. This reveals something about the contained value!\n",
     "\n",
     "As a fix, we introduce a **random blinding factor** $r$.\n",
     "\n",
@@ -271,7 +271,7 @@
     "\n",
     "To commit to values $v_0$, $v_1$, $\\ldots$, $v_n$, we create the **single curve point** $\\text{Com}(v_0, v_1, \\ldots, v_n; r) = G_0 * v_0 + G_1 * v_1 + \\ldots + G_n * v_n + H * r$ where $r$ is random.\n",
     "\n",
-    "Notice how the list of values is compressed inside a single curve point! The commitment is extremly space-efficient (constant size). Opening the commitment requires revealing the list of values and the blinding factor (linear size).\n",
+    "Notice how the list of values is compressed inside a single curve point! The commitment is extremely space-efficient (constant size). Opening the commitment requires revealing the list of values and the blinding factor (linear size).\n",
     "\n",
     "The commitment is **hiding** because of the blinding factor.\n",
     "\n",

--- a/graph/three_coloring.ipynb
+++ b/graph/three_coloring.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this chapter we construct a zero-knowledge protocol around graph colorability.\n",
     "\n",
-    "This chaper was inspired by [a video by Numberphile](https://www.youtube.com/watch?v=5ovdoxnfFVc) and is based on [a lecture from the Max Plack Institute for Informatics](https://resources.mpi-inf.mpg.de/departments/d1/teaching/ss13/gitcs/lecture9.pdf)."
+    "This chapter was inspired by [a video by Numberphile](https://www.youtube.com/watch?v=5ovdoxnfFVc) and is based on [a lecture from the Max Plack Institute for Informatics](https://resources.mpi-inf.mpg.de/departments/d1/teaching/ss13/gitcs/lecture9.pdf)."
    ]
   },
   {
@@ -242,7 +242,7 @@
     "        # Invalid coloring\n",
     "        if colored_edge[0].value() == colored_edge[1].value():\n",
     "            return False\n",
-    "        # Openened colors correspond to commitments\n",
+    "        # Opened colors correspond to commitments\n",
     "        if not colored_edge[0].verify(self.commitments[self.edge[0]]):\n",
     "            return False\n",
     "        if not colored_edge[1].verify(self.commitments[self.edge[1]]):\n",


### PR DESCRIPTION
- **commitments.ipynb**  
  - Fixed typo: `Commiting` → `Committing`
  - Fixed typo: `extremly` → `extremely`
  
- **three_coloring.ipynb**  
  - Fixed typo: `chaper` → `chapter`
  - Fixed typo: `Openened` → `Opened`

